### PR TITLE
use strict mode

### DIFF
--- a/lib/diagram/generator.js
+++ b/lib/diagram/generator.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const _ = require('lodash');
 const Node = require('./node');
 const Relation = require('./relation');

--- a/lib/diagram/index.js
+++ b/lib/diagram/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const generator = require('./generator');
 
 let nomnomlSource = '';

--- a/lib/diagram/node.js
+++ b/lib/diagram/node.js
@@ -1,3 +1,5 @@
+'use strict';
+
 class Node {
   constructor(name, specialize, generalization) {
     this.name = name;

--- a/lib/diagram/relation.js
+++ b/lib/diagram/relation.js
@@ -1,3 +1,5 @@
+'use strict';
+
 class Relation {
   constructor(source, destination, type) {
     this.source = source;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-disable no-mixed-operators */
 const _ = require('lodash');
 const routes = require('./routes');

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const diagram = require('./diagram');
 


### PR DESCRIPTION
Hello,

I get this error when I'm trying to use your component : 
```bash
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```

In order to work correctly with ES6 keywords, I add in each file `'use strict';` to specify to use strict mode.

Thanks in advance,
Fabrice.
