### PR TITLE
Remove inherited properties

### DIFF
--- a/lib/diagram/generator.js
+++ b/lib/diagram/generator.js
@@ -264,15 +264,17 @@ function getNodePropertyTypeFromReferencesMany(propertyName, loopbackRelations) 
  * Returns an array of node properties considering the embedded
  * and the reference relations as properties.
  */
-function extractNodeProperties(properties, loopbackRelations) {
+function extractNodeProperties(properties, baseProperties, loopbackRelations) {
   const nodeProperties = [];
 
   Object.keys(properties).forEach((propertyName) => {
+    if (baseProperties[propertyName]) {
+      return;
+    }
     const property = properties[propertyName];
     const nodeProperty = {
       name: propertyName,
     };
-
     if (Array.isArray(property.type)) {
       if (property.type[0].name === 'ModelConstructor') {
         nodeProperty.type = `${property.type[0].modelName}\\[\\]`;
@@ -317,6 +319,23 @@ function getRelations(models) {
 }
 
 /**
+ * Returns a map of all the inherited methods keyed by method name
+ * @param model
+ */
+function gatherInheritedMethods(model) {
+  const inheritedMethods = {};
+  while (model.base) {
+    model = model.base;
+    if (model.definition) {
+      Object.keys(model.definition.properties).forEach(function (propertyName) {
+        inheritedMethods[propertyName] = model.definition.properties[propertyName];
+      });
+    }
+  }
+  return inheritedMethods;
+}
+
+/**
  * Returns an array of nodes representing the models.
  */
 function mapModelsToNodes(loopbackApplication) {
@@ -335,7 +354,8 @@ function mapModelsToNodes(loopbackApplication) {
     const baseNode = getOrCreateNodeEntry(nodes, new Node(base.modelName));
 
     const node = getOrCreateNodeEntry(nodes, new Node(modelName, baseNode));
-    node.setProperties(extractNodeProperties(model.definition.properties, loopbackRelations));
+    const baseProperties = gatherInheritedMethods(model);
+    node.setProperties(extractNodeProperties(model.definition.properties, baseProperties, loopbackRelations));
 
     if (!_.isEmpty(model.relations)) {
       Object.keys(model.relations).forEach((relationName) => {

--- a/lib/diagram/generator.js
+++ b/lib/diagram/generator.js
@@ -355,7 +355,8 @@ function mapModelsToNodes(loopbackApplication, options) {
     const baseNode = getOrCreateNodeEntry(nodes, new Node(base.modelName));
 
     const node = getOrCreateNodeEntry(nodes, new Node(modelName, baseNode));
-    if (options.hideInherited && options.hideInherited.toLowerCase() === 'true') {
+    // handle boolean true and string "true" as it may come from query parameter or loopback config
+    if (options.hideInherited === true || options.hideInherited && options.hideInherited.toLowerCase() === 'true') {
       allBaseProperties = gatherInheritedProperties(model);
     }
     node.setProperties(extractNodeProperties(model.definition.properties, allBaseProperties, loopbackRelations));

--- a/lib/diagram/generator.js
+++ b/lib/diagram/generator.js
@@ -338,11 +338,12 @@ function gatherInheritedProperties(model) {
 /**
  * Returns an array of nodes representing the models.
  */
-function mapModelsToNodes(loopbackApplication) {
+function mapModelsToNodes(loopbackApplication, options) {
   const models = loopbackApplication.models();
   const loopbackRelations = getRelations(models);
   const nodes = new Map();
   const relationsToIgnore = [];
+  let allBaseProperties = {};
 
   models.forEach((model) => {
     const modelName = model.modelName;
@@ -354,7 +355,9 @@ function mapModelsToNodes(loopbackApplication) {
     const baseNode = getOrCreateNodeEntry(nodes, new Node(base.modelName));
 
     const node = getOrCreateNodeEntry(nodes, new Node(modelName, baseNode));
-    const allBaseProperties = gatherInheritedProperties(model);
+    if (options.hideInherited && options.hideInherited.toLowerCase() === 'true') {
+      allBaseProperties = gatherInheritedProperties(model);
+    }
     node.setProperties(extractNodeProperties(model.definition.properties, allBaseProperties, loopbackRelations));
 
     if (!_.isEmpty(model.relations)) {
@@ -430,7 +433,7 @@ function getNomnomlSourceDirectives(directives) {
  * Generate the nomnoml source of the given models.
  */
 function generate(loopbackApplication, options) {
-  const nodes = mapModelsToNodes(loopbackApplication);
+  const nodes = mapModelsToNodes(loopbackApplication, options);
   let nomnomlSource = '';
 
   if (options) {

--- a/lib/diagram/generator.js
+++ b/lib/diagram/generator.js
@@ -264,11 +264,11 @@ function getNodePropertyTypeFromReferencesMany(propertyName, loopbackRelations) 
  * Returns an array of node properties considering the embedded
  * and the reference relations as properties.
  */
-function extractNodeProperties(properties, baseProperties, loopbackRelations) {
+function extractNodeProperties(properties, allBaseProperties, loopbackRelations) {
   const nodeProperties = [];
 
   Object.keys(properties).forEach((propertyName) => {
-    if (baseProperties[propertyName]) {
+    if (allBaseProperties[propertyName]) {
       return;
     }
     const property = properties[propertyName];
@@ -319,20 +319,20 @@ function getRelations(models) {
 }
 
 /**
- * Returns a map of all the inherited methods keyed by method name
+ * Returns a map of all the inherited properties keyed by property name
  * @param model
  */
-function gatherInheritedMethods(model) {
-  const inheritedMethods = {};
+function gatherInheritedProperties(model) {
+  const inheritedProperties = {};
   while (model.base) {
     model = model.base;
     if (model.definition) {
       Object.keys(model.definition.properties).forEach(function (propertyName) {
-        inheritedMethods[propertyName] = model.definition.properties[propertyName];
+        inheritedProperties[propertyName] = model.definition.properties[propertyName];
       });
     }
   }
-  return inheritedMethods;
+  return inheritedProperties;
 }
 
 /**
@@ -354,8 +354,8 @@ function mapModelsToNodes(loopbackApplication) {
     const baseNode = getOrCreateNodeEntry(nodes, new Node(base.modelName));
 
     const node = getOrCreateNodeEntry(nodes, new Node(modelName, baseNode));
-    const baseProperties = gatherInheritedMethods(model);
-    node.setProperties(extractNodeProperties(model.definition.properties, baseProperties, loopbackRelations));
+    const allBaseProperties = gatherInheritedProperties(model);
+    node.setProperties(extractNodeProperties(model.definition.properties, allBaseProperties, loopbackRelations));
 
     if (!_.isEmpty(model.relations)) {
       Object.keys(model.relations).forEach((relationName) => {

--- a/lib/diagram/index.js
+++ b/lib/diagram/index.js
@@ -1,15 +1,22 @@
 const generator = require('./generator');
 
-let nomnomlSource = '';
+const nomnomlSourceCache = {};
 
 const diagram = (loopbackApplication, options) => {
-  if (nomnomlSource) {
-    return nomnomlSource;
+  const optionsKey = JSON.stringify(options);
+  let cachedValue = nomnomlSourceCache[optionsKey];
+  if (cachedValue) {
+    return cachedValue;
   }
 
-  nomnomlSource = generator.generate(loopbackApplication, options);
-
-  return nomnomlSource;
+  cachedValue = generator.generate(loopbackApplication, options);
+  // something fishy is going on if there are more then 50 cache values.
+  // Safely don't cache it for now to avoid malicious OOMs.
+  // a Poor mans LRU cache - suitable because there are not many permutations expected
+  if (Object.keys(nomnomlSourceCache).length < 50) {
+    nomnomlSourceCache[optionsKey] = cachedValue;
+  }
+  return cachedValue;
 };
 
 module.exports = diagram;

--- a/lib/public/scripts/main.js
+++ b/lib/public/scripts/main.js
@@ -87,7 +87,7 @@
       }
     };
 
-    xhttp.open('GET', 'source/', true);
+    xhttp.open('GET', 'source/' + location.search, true);
     xhttp.send();
   }
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const path = require('path');
 const diagram = require('./diagram');
 
@@ -6,7 +7,8 @@ const routes = (loopbackApplication, router, options) => {
   const publicDir = 'public';
 
   router.get('/source', (req, res) => {
-    const diagramSource = diagram(loopbackApplication, options);
+    const opts = _.defaults({}, req.query, options);
+    const diagramSource = diagram(loopbackApplication, opts);
     res.send(diagramSource);
   });
 

--- a/loopback-component-model-diagram.iml
+++ b/loopback-component-model-diagram.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/loopback-component-model-diagram.iml
+++ b/loopback-component-model-diagram.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>


### PR DESCRIPTION
Currently the child models were showing properties inherited from the
parent. This was cluttering up the uml for large projects.