### PR TITLE
Bugfix for model inheritance and embedded relation processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 coverage
 *.log
+.DS_Store
+.idea

--- a/lib/diagram/generator.js
+++ b/lib/diagram/generator.js
@@ -377,7 +377,11 @@ function mapModelsToNodes(loopbackApplication, options) {
     const baseNode = getOrCreateNodeEntry(nodes, new Node(base.modelName));
 
     const node = getOrCreateNodeEntry(nodes, new Node(modelName, baseNode));
-    node.setProperties(extractNodeProperties(model.definition.properties, loopbackRelations));
+    // handle boolean true and string "true" as it may come from query parameter or loopback config
+    if ((options.hideInherited === true) || (options.hideInherited && options.hideInherited.toLowerCase() === 'true')) {
+      allBaseProperties = gatherInheritedProperties(model);
+    }
+    node.setProperties(extractNodeProperties(model.definition.properties, allBaseProperties, loopbackRelations));
   });
 
   models.forEach((model) => {
@@ -422,13 +426,20 @@ function mapModelsToNodes(loopbackApplication, options) {
           } else if (rel.type === 'belongsTo' && !rel.polymorphic) {
             handleBelongsTo(nodes, node, rel, relationsToIgnore);
 
-            // embedsOne relation
-          } else if (rel.type === 'embedsOne') {
-            handleEmbedsOne(nodes, node, rel);
+            // Optional relations
+          } else if (
+            (options.showEmbeddedRelations === true)
+            ||
+            (options.showEmbeddedRelations && options.showEmbeddedRelations.toLowerCase() === 'true')
+          ) {
+              // embedsOne relation
+            if (options.showEmbeddedRelations && rel.type === 'embedsOne') {
+              handleEmbedsOne(nodes, node, rel);
 
-            // embedsMany relation
-          } else if (rel.type === 'embedsMany') {
-            handleEmbedsMany(nodes, node, rel);
+              // embedsMany relation
+            } else if (rel.type === 'embedsMany') {
+              handleEmbedsMany(nodes, node, rel);
+            }
           }
         }
       });

--- a/lib/diagram/generator.js
+++ b/lib/diagram/generator.js
@@ -377,15 +377,12 @@ function mapModelsToNodes(loopbackApplication, options) {
     const baseNode = getOrCreateNodeEntry(nodes, new Node(base.modelName));
 
     const node = getOrCreateNodeEntry(nodes, new Node(modelName, baseNode));
+    node.specialize = baseNode;
     // handle boolean true and string "true" as it may come from query parameter or loopback config
     if ((options.hideInherited === true) || (options.hideInherited && options.hideInherited.toLowerCase() === 'true')) {
       allBaseProperties = gatherInheritedProperties(model);
     }
     node.setProperties(extractNodeProperties(model.definition.properties, allBaseProperties, loopbackRelations));
-  });
-
-  models.forEach((model) => {
-    const node = nodes.get(model.modelName);
 
     if (!_.isEmpty(model.relations)) {
       Object.keys(model.relations).forEach((relationName) => {

--- a/lib/diagram/generator.js
+++ b/lib/diagram/generator.js
@@ -27,7 +27,7 @@ function getOrCreateNodeEntry(map, node) {
 }
 
 function containsObject(array, obj) {
-  return array.some((element) => {
+  return _.some(array, (element) => {
     if (element === obj) {
       return true;
     }
@@ -270,7 +270,7 @@ function getNomnomlSourceFromNodes(nodes) {
 function getNodePropertyTypeFromReferencesMany(propertyName, loopbackRelations) {
   let nodePropertyType = '';
 
-  loopbackRelations.some((loopbackRelation) => {
+  _.some(loopbackRelations, (loopbackRelation) => {
     if (loopbackRelation.keyFrom === propertyName && loopbackRelation.type === 'referencesMany') {
       nodePropertyType = `*${loopbackRelation.modelTo.modelName}\\[\\]`;
       return true;

--- a/lib/diagram/generator.js
+++ b/lib/diagram/generator.js
@@ -185,6 +185,24 @@ function handleHasAndBelongsToManyPolymorphic(nodes, node, relation) {
 }
 
 /**
+ * Handle the embedsOne relation.
+ */
+function handleEmbedsOne(nodes, node, relation) {
+  const destination = getOrCreateNodeEntry(nodes, new Node(relation.modelTo.modelName));
+  const rel = new Relation(node, destination, 'embedsOne');
+  node.addRelation(rel);
+}
+
+/**
+ * Handle the embedsMany relation.
+ */
+function handleEmbedsMany(nodes, node, relation) {
+  const destination = getOrCreateNodeEntry(nodes, new Node(relation.modelTo.modelName));
+  const rel = new Relation(node, destination, 'embedsMany');
+  node.addRelation(rel);
+}
+
+/**
  * Returns a string with the arrow in between the
  * source and the destination node nomnoml code.
  */
@@ -237,6 +255,10 @@ function getNomnomlSourceFromNodes(nodes) {
           } else {
             nomnomlSource += printConnection(rel, '<->');
           }
+        } else if (rel.type === 'embedsOne') {
+          nomnomlSource += printConnection(rel, 'o-');
+        } else if (rel.type === 'embedsMany') {
+          nomnomlSource += printConnection(rel, 'o-');
         }
       });
     }
@@ -399,6 +421,14 @@ function mapModelsToNodes(loopbackApplication, options) {
             // belongsTo relation
           } else if (rel.type === 'belongsTo' && !rel.polymorphic) {
             handleBelongsTo(nodes, node, rel, relationsToIgnore);
+
+            // embedsOne relation
+          } else if (rel.type === 'embedsOne') {
+            handleEmbedsOne(nodes, node, rel);
+
+            // embedsMany relation
+          } else if (rel.type === 'embedsMany') {
+            handleEmbedsMany(nodes, node, rel);
           }
         }
       });

--- a/lib/diagram/generator.js
+++ b/lib/diagram/generator.js
@@ -355,11 +355,11 @@ function mapModelsToNodes(loopbackApplication, options) {
     const baseNode = getOrCreateNodeEntry(nodes, new Node(base.modelName));
 
     const node = getOrCreateNodeEntry(nodes, new Node(modelName, baseNode));
-    // handle boolean true and string "true" as it may come from query parameter or loopback config
-    if (options.hideInherited === true || options.hideInherited && options.hideInherited.toLowerCase() === 'true') {
-      allBaseProperties = gatherInheritedProperties(model);
-    }
-    node.setProperties(extractNodeProperties(model.definition.properties, allBaseProperties, loopbackRelations));
+    node.setProperties(extractNodeProperties(model.definition.properties, loopbackRelations));
+  });
+
+  models.forEach((model) => {
+    const node = nodes.get(model.modelName);
 
     if (!_.isEmpty(model.relations)) {
       Object.keys(model.relations).forEach((relationName) => {

--- a/lib/diagram/relation.js
+++ b/lib/diagram/relation.js
@@ -10,6 +10,8 @@ class Relation {
      * - belongsTo
      * - hasAndBelongsToMany
      * - generalize (used in a polymorphic relation from the generalization
+     * - embedsOne
+     * - embedsMany
      * model to the concrete model)
      */
     this.type = type;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-component-model-diagram",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Generate a diagram of your loopback models",
   "homepage": "https://github.com/redbabel/loopback-component-model-diagram",
   "files": [


### PR DESCRIPTION
Good day!

I would like to say that this is amazing component for loopback. I found a few issues which I had to fix prior to adding it to my project.

In my case, the first issue was as following:
I have entities Researcher, Test, PrivateTest, PublicTest. PrivateTest and PublicTest based on the Test model.

All of the three models are related to Researcher model using relation defined in the Test model:

```JSON
    "researcher": {
      "type": "belongsTo",
      "model": "Researcher",
      "foreignKey": ""
    }
```

Researcher model has following relation with PrivateTest:

```JSON
    "privateTests": {
      "type": "hasMany",
      "model": "PrivateTest",
      "foreignKey": ""
    }
```

It was expected to see both PrivateTest and PublicTest inherited from the Test model, but instead only the PublicTest was inherited. The issue was related to the execution order.

Other issues are minor ones (such as missing .some method for arrays, which I had to replace using lodash).

Also I've added aggregation relations between models which use embedsOne and embedsMany relations.

Please, review my changes.