### PR TITLE
Fix engine version matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">6.x.x"
+    "node": ">=6.x.x"
   },
   "main": "lib/index.js",
   "keywords": [


### PR DESCRIPTION
Engine specifies ">6.x.x" which means any version of node@6 is not considered to match:

```
> semver.satisfies('6.13.1', '>6.x.x')
false
> semver.satisfies('6.13.1', '>=6.x.x')
true
```