### PR TITLE
Fix for 'undefined' polymorphic relation name

### DIFF
--- a/lib/diagram/generator.js
+++ b/lib/diagram/generator.js
@@ -92,7 +92,7 @@ function handleHasOne(nodes, node, relation) {
 function handleHasOnePolymorphic(nodes, node, relation) {
   const destination = getOrCreateNodeEntry(nodes, new Node(relation.modelTo.modelName));
 
-  const asNode = getOrCreateNodeEntry(nodes, new Node(relation.polymorphic.as, null, true));
+  const asNode = getOrCreateNodeEntry(nodes, new Node(relation.name, null, true));
   const asNodeRelation = new Relation(asNode, destination, 'generalize');
   asNode.setRelation(asNodeRelation);
   nodes.set(asNode.name, asNode);
@@ -118,7 +118,7 @@ function handleHasMany(nodes, node, relation) {
 function handleHasManyPolymorphic(nodes, node, relation) {
   const destination = getOrCreateNodeEntry(nodes, new Node(relation.modelTo.modelName));
 
-  const asNode = getOrCreateNodeEntry(nodes, new Node(relation.polymorphic.as, null, true));
+  const asNode = getOrCreateNodeEntry(nodes, new Node(relation.name, null, true));
   const asNodeRelation = new Relation(asNode, destination, 'generalize');
   asNode.setRelation(asNodeRelation);
   nodes.set(asNode.name, asNode);

--- a/lib/diagram/generator.js
+++ b/lib/diagram/generator.js
@@ -92,7 +92,8 @@ function handleHasOne(nodes, node, relation) {
 function handleHasOnePolymorphic(nodes, node, relation) {
   const destination = getOrCreateNodeEntry(nodes, new Node(relation.modelTo.modelName));
 
-  const asNode = getOrCreateNodeEntry(nodes, new Node(relation.name, null, true));
+  const nodeName = relation.polymorphic.as || relation.name;
+  const asNode = getOrCreateNodeEntry(nodes, new Node(nodeName, null, true));
   const asNodeRelation = new Relation(asNode, destination, 'generalize');
   asNode.setRelation(asNodeRelation);
   nodes.set(asNode.name, asNode);
@@ -118,7 +119,8 @@ function handleHasMany(nodes, node, relation) {
 function handleHasManyPolymorphic(nodes, node, relation) {
   const destination = getOrCreateNodeEntry(nodes, new Node(relation.modelTo.modelName));
 
-  const asNode = getOrCreateNodeEntry(nodes, new Node(relation.name, null, true));
+  const nodeName = relation.polymorphic.as || relation.name;
+  const asNode = getOrCreateNodeEntry(nodes, new Node(nodeName, null, true));
   const asNodeRelation = new Relation(asNode, destination, 'generalize');
   asNode.setRelation(asNodeRelation);
   nodes.set(asNode.name, asNode);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-component-model-diagram",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Generate a diagram of your loopback models",
   "homepage": "https://github.com/redbabel/loopback-component-model-diagram",
   "files": [


### PR DESCRIPTION
Good day!

Some time ago the Datasource Juggler project stopped using "relation.polymorphic.as" property: https://github.com/strongloop/loopback-datasource-juggler/issues/1298

Thus I think it is acceptable to use a fallback to the "relation.name" property to support newer versions of Datasource Juggler.

Please, review my changes.